### PR TITLE
Add common features

### DIFF
--- a/bubble/include/Common/Memory.hxx
+++ b/bubble/include/Common/Memory.hxx
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <sys/resource.h>
+
+long get_memory_checkpoint()
+{
+  rusage obj;
+  int who = 0;
+  [[maybe_unused]] auto test = getrusage(who, &obj);
+  assert((test = -1) && "error: getrusage has failed");
+  long res;
+  MPI_Reduce(&(obj.ru_maxrss), &(res), 1, MPI_LONG, MPI_SUM, 0, MPI_COMM_WORLD);
+
+  return res;
+};
+
+void print_memory_footprint(std::string msg)
+{
+  long mem = get_memory_checkpoint();
+  double m = double(mem) * 1e-6; // conversion kb to Gb
+  mfem_mgis::Profiler::Utils::Message(msg, " memory footprint: ", m, " GB");
+}
+

--- a/bubble/include/Common/Print.hxx
+++ b/bubble/include/Common/Print.hxx
@@ -1,0 +1,41 @@
+#pragma once
+
+#include "MFEMMGIS/NonLinearEvolutionProblemImplementation.hxx"
+#include "MFEMMGIS/NonLinearEvolutionProblem.hxx"
+#include <MFEMMGIS/Profiler.hxx>
+
+
+  template<typename Implementation>
+void print_mesh_information(Implementation& impl)
+{
+
+  using mfem_mgis::Profiler::Utils::sum;
+  using mfem_mgis::Profiler::Utils::Message;
+  Message("INFO: print_mesh_information");
+
+  //getMesh
+  auto mesh = impl.getFiniteElementSpace().GetMesh();
+
+  //get the number of vertices
+  int64_t numbers_of_vertices_local = mesh->GetNV();
+  int64_t  numbers_of_vertices = sum(numbers_of_vertices_local);
+
+  //get the number of elements
+  int64_t numbers_of_elements_local = mesh->GetNE();
+  int64_t numbers_of_elements = sum(numbers_of_elements_local);
+
+  //get the element size
+  double h = mesh->GetElementSize(0);
+
+  // get n dofs
+  auto& fespace = impl.getFiniteElementSpace();
+  int64_t unknowns_local = fespace.GetTrueVSize();
+  int64_t unknowns = sum(unknowns_local);
+
+  Message("INFO: number of vertices -> ", numbers_of_vertices);
+  Message("INFO: number of elements -> ", numbers_of_elements);
+  Message("INFO: element size -> ", h);
+  Message("INFO: Number of finite element unknowns: " , unknowns);
+}
+
+


### PR DESCRIPTION
- Print the memory footprint
- Print problem information
- Add TestParameters for more flexibility.

Parameters : 
```
Usage: ./test-bubble [options] ...
Options:
   -h, --help
	Print this help message and exit.
   -m <string>, --mesh <string>, current value: mesh/mesh_sphere.msh
	Mesh file to use.
   -l <string>, --library <string>, current value: src/libBehaviour.so
	Material library.
   -f <string>, --bubble-file <string>, current value: src/libBehaviour.so
	File containing the bubbles.
   -o <int>, --order <int>, current value: 1
	Finite element order (polynomial degree).
   -r <int>, --refinement <int>, current value: 0
	refinement level of the mesh, default = 0
   -p <int>, --post-processing <int>, current value: 1
	run post processing step
   -v <int>, --verbosity-level <int>, current value: 0
	choose the verbosity level
```